### PR TITLE
Add cflinuxfs5 support for staticfile buildpack

### DIFF
--- a/jobs/staticfile-buildpack/spec
+++ b/jobs/staticfile-buildpack/spec
@@ -3,6 +3,7 @@ name: staticfile-buildpack
 templates: {}
 
 packages:
+- staticfile-buildpack-cflinuxfs5
 - staticfile-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/staticfile-buildpack-cflinuxfs5/packaging
+++ b/packages/staticfile-buildpack-cflinuxfs5/packaging
@@ -1,2 +1,2 @@
-      set -e -x
-      cp staticfile-buildpack/staticfile?buildpack-*.zip ${BOSH_INSTALL_TARGET}
+    set -e -x
+    cp staticfile-buildpack/staticfile?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/staticfile-buildpack-cflinuxfs5/packaging
+++ b/packages/staticfile-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,2 @@
+      set -e -x
+      cp staticfile-buildpack/staticfile?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/staticfile-buildpack-cflinuxfs5/spec
+++ b/packages/staticfile-buildpack-cflinuxfs5/spec
@@ -1,4 +1,4 @@
 ---
-  name: staticfile-buildpack-cflinuxfs5
-  files:
-  - staticfile-buildpack/staticfile?buildpack-cflinuxfs5-*.zip
+name: staticfile-buildpack-cflinuxfs5
+files:
+- staticfile-buildpack/staticfile?buildpack-cflinuxfs5-*.zip

--- a/packages/staticfile-buildpack-cflinuxfs5/spec
+++ b/packages/staticfile-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+  name: staticfile-buildpack-cflinuxfs5
+  files:
+  - staticfile-buildpack/staticfile?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the staticfile-buildpack BOSH release, following the same pattern used for cflinuxfs4.

Changes:
- Create packages/staticfile-buildpack-cflinuxfs5/spec - package specification
- Create packages/staticfile-buildpack-cflinuxfs5/packaging - build script
- Update jobs/staticfile-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy PHP applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.